### PR TITLE
abort if glyph "not worth outputting"

### DIFF
--- a/fontforge_font_creator/creator.py
+++ b/fontforge_font_creator/creator.py
@@ -35,6 +35,7 @@ class FontMaker:
     def add_glyph(self, hex_position, svg):
         glyph = self.fontforge_font.createChar(hex_position)
         glyph.importOutlines(os.path.join(self._base_path, svg))
+        assert glyph.isWorthOutputting()
 
     def create_font(self):
         for font, definition in self.config.items():


### PR DESCRIPTION
Abort if glyph "not worth outputting" as FontForge actually wouldn't put it into the TTF font, then.

Should avoid a glyph missing because the SVG file

> is too complex for [FontForge] to understand (or is erroneous)

as it were in #21 due to strokes instead of paths in SVG.
### Reviewed by
- [x] @hixi
