### PR TITLE
documentation of air_traffic line features with/after #422

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -834,6 +834,18 @@ railway_ground_l: bridge = 0, tunnel = 0
 |other_traffic|aerialway_station|aerialway='station' |A station, where passengers can enter and/or leave the aerialway|
 
 
+## transport_l
+
+
+ Values of attributes type  
+
+|aggtype             |values              |osm_tags            |description                                                           |
+| ------------------ | ------------------ | ------------------ | -------------------------------------------------------------------- |
+|air_traffic|apron|aeroway='taxiway' |An apron is the surfaced part of an airport where planes park.|
+|air_traffic|runway|aeroway='runway' |Where airplanes take off and land|
+|air_traffic|taxiway|aeroway='taxiway' |Where airplanes manouevre between runways and parking areas.|
+
+
 ## utility_a
 
 |Attributes          |type                |Description                                                           |osm_tags            |

--- a/osmaxx_schema.yaml
+++ b/osmaxx_schema.yaml
@@ -2816,19 +2816,19 @@ layers:
             correlated_attributes:
               "aggtype": 'air_traffic'
             description: 'An Aerodrome (UK), Airport (US)'
-          "taxiway":
+          "taxiway": &transport_type_taxiway
             osm_tags:
              - "aeroway": 'taxiway'
             correlated_attributes:
               "aggtype": 'air_traffic'
             description: 'Where airplanes manouevre between runways and parking areas.'
-          "apron":
+          "apron": &transport_type_apron
             osm_tags:
              - "aeroway": 'apron'
             correlated_attributes:
               "aggtype": 'air_traffic'
             description: 'An apron is the surfaced part of an airport where planes park.'
-          "runway":
+          "runway": &transport_type_runway
             osm_tags:
              - "aeroway": 'runway'
             correlated_attributes:
@@ -2871,6 +2871,14 @@ layers:
               "aggtype": 'public_transport'
             description: 'Where public transports stop to pick up passengers'
   "transport_p": *layer_transport_a
+  "transport_l":
+          "taxiway": *transport_type_taxiway
+          "apron": *transport_type_apron
+          "runway": *transport_type_runway
+    attributes:
+      "type":
+        type: text
+        values:
   "utility_a": &layer_utility_a
     attributes:
       "aggtype":

--- a/osmaxx_schema.yaml
+++ b/osmaxx_schema.yaml
@@ -2824,7 +2824,7 @@ layers:
             description: 'Where airplanes manouevre between runways and parking areas.'
           "apron":
             osm_tags:
-             - "aeroway": 'taxiway'
+             - "aeroway": 'apron'
             correlated_attributes:
               "aggtype": 'air_traffic'
             description: 'An apron is the surfaced part of an airport where planes park.'


### PR DESCRIPTION
Connected to geometalab/osmaxx-frontend#422
Connected to #9

(Hand-edited the MarkDown file `documentation.md`, didn't re-generate it.)
### Reviewed by
- [ ] @beneditatan
- [x] @sfkeller
- [x] @hixi
