### PR TITLE
document classification of nonop ways

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -517,6 +517,7 @@ Values of attribute type
 | ------------------ | ------------------ | -------------------------------------------------------------------- | ------------------ |
 |ref|text|Reference number of this road unset for railways.|`ref=*`|
 |status|text| |(see table below)|
+|sub_type|text|See attribute 'type' of layer road_l and railway_l, respectively.|`highway=planned`+`planned=*` or `highway=construction`+`construction=*` or `highway=disused`+`disused=*` or `highway=abandoned`+`abandoned=*` or `railway=planned`+`planned=*` or `railway=construction`+`construction=*` or `railway=disused`+`disused=*` or `railway=abandoned`+`abandoned=*`|
 |type|text| |(see table below)|
 |z_order|smallint|The layer tag is used to describe vertical relationships between different crossing or overlapping map features. Use this in combination with bridge/tunnel tags when one way passes above or under another one.|`layer=*`|
 

--- a/documentation.md
+++ b/documentation.md
@@ -196,7 +196,7 @@ See file name conventions above about the meaning of “_a” etc.
 
 |Attributes          |type                |Description                                                           |osm_tags            |
 | ------------------ | ------------------ | -------------------------------------------------------------------- | ------------------ |
-|type|text| |(see table below)|
+|type|text|(see table below)| |
 
 
 Values of attribute type
@@ -224,7 +224,7 @@ Values of attribute type
 
 |Attributes          |type                |Description                                                           |osm_tags            |
 | ------------------ | ------------------ | -------------------------------------------------------------------- | ------------------ |
-|type|text| |(see table below)|
+|type|text|(see table below)| |
 
 
 Values of attribute type
@@ -253,7 +253,7 @@ Values of attribute type
 |Attributes          |type                |Description                                                           |osm_tags            |
 | ------------------ | ------------------ | -------------------------------------------------------------------- | ------------------ |
 |height|text|Stores the height of the building (Unit Meters)|`height=*`|
-|type|text| |(see table below)|
+|type|text|(see table below)| |
 
 
 Values of attribute type
@@ -269,7 +269,7 @@ Values of attribute type
 |Attributes          |type                |Description                                                           |osm_tags            |
 | ------------------ | ------------------ | -------------------------------------------------------------------- | ------------------ |
 |population|int|A rough number of citizens in a given place|`population=*`|
-|type|text| |(see table below)|
+|type|text|(see table below)| |
 |wikipedia|text|Provide a reference to an article in Wikipedia about the feature|`wikipedia=*`|
 
 
@@ -302,7 +302,7 @@ Values of attribute type
 |Attributes          |type                |Description                                                           |osm_tags            |
 | ------------------ | ------------------ | -------------------------------------------------------------------- | ------------------ |
 |population|int|A rough number of citizens in a given place|`population=*`|
-|type|text| |(see table below)|
+|type|text|(see table below)| |
 |wikipedia|text|Provide a reference to an article in Wikipedia about the feature|`wikipedia=*`|
 
 
@@ -334,7 +334,7 @@ Values of attribute type
 
 |Attributes          |type                |Description                                                           |osm_tags            |
 | ------------------ | ------------------ | -------------------------------------------------------------------- | ------------------ |
-|type|| |(see table below)|
+|type||(see table below)| |
 
 
 Values of attribute type
@@ -374,7 +374,7 @@ Values of attribute type
 
 |Attributes          |type                |Description                                                           |osm_tags            |
 | ------------------ | ------------------ | -------------------------------------------------------------------- | ------------------ |
-|type|text| |(see table below)|
+|type|text|(see table below)| |
 
 
 Values of attribute type
@@ -399,7 +399,7 @@ Values of attribute type
 
 |Attributes          |type                |Description                                                           |osm_tags            |
 | ------------------ | ------------------ | -------------------------------------------------------------------- | ------------------ |
-|type|text| |(see table below)|
+|type|text|(see table below)| |
 
 
 Values of attribute type
@@ -424,7 +424,7 @@ Values of attribute type
 
 |Attributes          |type                |Description                                                           |osm_tags            |
 | ------------------ | ------------------ | -------------------------------------------------------------------- | ------------------ |
-|type|text| |(see table below)|
+|type|text|(see table below)| |
 
 
 Values of attribute type
@@ -453,7 +453,7 @@ Values of attribute type
 
 |Attributes          |type                |Description                                                           |osm_tags            |
 | ------------------ | ------------------ | -------------------------------------------------------------------- | ------------------ |
-|type|text| |(see table below)|
+|type|text|(see table below)| |
 
 
 Values of attribute type
@@ -484,7 +484,7 @@ Values of attribute type
 
 |Attributes          |type                |Description                                                           |osm_tags            |
 | ------------------ | ------------------ | -------------------------------------------------------------------- | ------------------ |
-|type|text| |(see table below)|
+|type|text|(see table below)| |
 
 
 Values of attribute type
@@ -516,9 +516,9 @@ Values of attribute type
 |Attributes          |type                |Description                                                           |osm_tags            |
 | ------------------ | ------------------ | -------------------------------------------------------------------- | ------------------ |
 |ref|text|Reference number of this road unset for railways.|`ref=*`|
-|status|text| |(see table below)|
+|status|text|(see table below)| |
 |sub_type|text|See attribute 'type' of layer road_l and railway_l, respectively.|`highway=proposed`+`proposed=*` or `highway=planned`+`planned=*` or `highway=construction`+`construction=*` or `highway=disused`+`disused=*` or `highway=abandoned`+`abandoned=*` or `railway=proposed`+`proposed=*` or `railway=planned`+`planned=*` or `railway=construction`+`construction=*` or `railway=disused`+`disused=*` or `railway=abandoned`+`abandoned=*`|
-|type|text| |(see table below)|
+|type|text|(see table below)| |
 |z_order|smallint|The layer tag is used to describe vertical relationships between different crossing or overlapping map features. Use this in combination with bridge/tunnel tags when one way passes above or under another one.|`layer=*`|
 
 
@@ -554,7 +554,7 @@ Values of attribute type
 |opening_hours|text|The timing of when something is open or close|`opening_hours=*`|
 |phone|text|A telephone number associated with the object.|`phone=*`|
 |tower_type|text|The type of tower|`tower:type=*`|
-|type|text| |(see table below)|
+|type|text|(see table below)| |
 |website|text|Specifying the link to the official website for a feature.|`website=*`|
 |wikipedia|text|Provide a reference to an article in Wikipedia about the feature.|`wikipedia=*`|
 
@@ -734,7 +734,7 @@ Values of attribute type
 |opening_hours|text|The timing of when something is open or close|`opening_hours=*`|
 |phone|text|A telephone number associated with the object.|`phone=*`|
 |tower_type|text|The type of tower|`tower:type=*`|
-|type|text| |(see table below)|
+|type|text|(see table below)| |
 |website|text|Specifying the link to the official website for a feature.|`website=*`|
 |wikipedia|text|Provide a reference to an article in Wikipedia about the feature.|`wikipedia=*`|
 
@@ -911,7 +911,7 @@ Values of attribute type
 |contact_phone|text|Phone number|`contact:phone=*`|
 |opening_hours|text|The timing of when something is open or close|`opening_hours=*`|
 |phone|text|A telephone number associated with the object.|`phone=*`|
-|type|text| |(see table below)|
+|type|text|(see table below)| |
 |website|text|Specifying the link to the official website for a feature.|`website=*`|
 |wikipedia|text|Provide a reference to an article in Wikipedia about the feature.|`wikipedia=*`|
 
@@ -953,7 +953,7 @@ Values of attribute type
 |contact_phone|text|Phone number|`contact:phone=*`|
 |opening_hours|text|The timing of when something is open or close|`opening_hours=*`|
 |phone|text|A telephone number associated with the object.|`phone=*`|
-|type|text| |(see table below)|
+|type|text|(see table below)| |
 |website|text|Specifying the link to the official website for a feature.|`website=*`|
 |wikipedia|text|Provide a reference to an article in Wikipedia about the feature.|`wikipedia=*`|
 
@@ -991,10 +991,10 @@ Values of attribute type
 |Attributes          |type                |Description                                                           |osm_tags            |
 | ------------------ | ------------------ | -------------------------------------------------------------------- | ------------------ |
 |aggtype|text|Grouping several different 'type' to a common 'type'. (aka enmu)| |
-|bridge|boolean|A bridge is an artificial construction that spans features such as roads, railways, waterways or valleys and carries a road, railway or other feature.|(see table below)|
+|bridge|boolean|A bridge is an artificial construction that spans features such as roads, railways, waterways or valleys and carries a road, railway or other feature. (see table below)| |
 |frequency|text|The electrical frequency that the electrified cable is running on|`frequency=*`|
-|tunnel|boolean|A tunnel is an underground passage for a road or similar.|(see table below)|
-|type|text| |(see table below)|
+|tunnel|boolean|A tunnel is an underground passage for a road or similar. (see table below)| |
+|type|text|(see table below)| |
 |voltage|text|The voltage level the electrified cable is running on|`voltage=*`|
 |z_order|smallint|The layer tag is used to describe vertical relationships between different crossing or overlapping map features. Use this in combination with bridge/tunnel tags when one way passes above or under another one. For describing different floors within a building or levels of multilevel parking decks use levels instead of layers.|`layer=*`|
 
@@ -1051,12 +1051,12 @@ Values of attribute type
 |Attributes          |type                |Description                                                           |osm_tags            |
 | ------------------ | ------------------ | -------------------------------------------------------------------- | ------------------ |
 |aggtype|text|Grouping several different 'type' to a common 'type'. (aka enmu)| |
-|bridge|boolean|A bridge is an artificial construction that spans features such as roads, railways, waterways or valleys and carries a road, railway or other feature.|(see table below)|
+|bridge|boolean|A bridge is an artificial construction that spans features such as roads, railways, waterways or valleys and carries a road, railway or other feature. (see table below)| |
 |maxspeed|smallint|Specifies the maximum legal speed limit on a road, railway or waterway|`maxspeed=*`|
 |oneway|boolean|Oneway streets are streets where you are only allowed to drive in one direction.|`oneway=*`|
 |ref|text|Used for reference numbers or codes. Common for roads, highway exits, routes, etc.|`ref=*`|
-|tunnel|boolean|A tunnel is an underground passage for a road or similar.|(see table below)|
-|type|text| |(see table below)|
+|tunnel|boolean|A tunnel is an underground passage for a road or similar. (see table below)| |
+|type|text|(see table below)| |
 |z_order|smallint|The layer tag is used to describe vertical relationships between different crossing or overlapping map features. Use this in combination with bridge/tunnel tags when one way passes above or under another one. For describing different floors within a building or levels of multilevel parking decks use levels instead of layers.|`layer=*`|
 
 
@@ -1116,7 +1116,7 @@ Values of attribute type
 
 |Attributes          |type                |Description                                                           |osm_tags            |
 | ------------------ | ------------------ | -------------------------------------------------------------------- | ------------------ |
-|type|text| |(see table below)|
+|type|text|(see table below)| |
 
 
 Values of attribute type
@@ -1153,7 +1153,7 @@ Values of attribute type
 | ------------------ | ------------------ | -------------------------------------------------------------------- | ------------------ |
 |access|text(later)|For describing the legal accessibility of a element.|`access=*`|
 |aggtype|text|Grouping several different 'type' to a common 'type'. (aka enmu)| |
-|type|text| |(see table below)|
+|type|text|(see table below)| |
 
 
 Values of attribute type
@@ -1175,7 +1175,7 @@ Values of attribute type
 | ------------------ | ------------------ | -------------------------------------------------------------------- | ------------------ |
 |access|text(later)|For describing the legal accessibility of a element.|`access=*`|
 |aggtype|text|Grouping several different 'type' to a common 'type'. (aka enmu)| |
-|type|text| |(see table below)|
+|type|text|(see table below)| |
 
 
 Values of attribute type
@@ -1225,7 +1225,7 @@ Values of attribute type
 
 |Attributes          |type                |Description                                                           |osm_tags            |
 | ------------------ | ------------------ | -------------------------------------------------------------------- | ------------------ |
-|type|text| |(see table below)|
+|type|text|(see table below)| |
 
 
 Values of attribute type
@@ -1254,7 +1254,7 @@ Values of attribute type
 
 |Attributes          |type                |Description                                                           |osm_tags            |
 | ------------------ | ------------------ | -------------------------------------------------------------------- | ------------------ |
-|type|text| |(see table below)|
+|type|text|(see table below)| |
 
 
 Values of attribute type
@@ -1271,7 +1271,7 @@ Values of attribute type
 
 |Attributes          |type                |Description                                                           |osm_tags            |
 | ------------------ | ------------------ | -------------------------------------------------------------------- | ------------------ |
-|type|text| |(see table below)|
+|type|text|(see table below)| |
 
 
 Values of attribute type
@@ -1301,7 +1301,7 @@ Values of attribute type
 |Attributes          |type                |Description                                                           |osm_tags            |
 | ------------------ | ------------------ | -------------------------------------------------------------------- | ------------------ |
 |aggtype|text|Grouping several different 'type' to a common 'type' (aka enmu)| |
-|type|text| |(see table below)|
+|type|text|(see table below)| |
 
 
 Values of attribute type
@@ -1330,7 +1330,7 @@ Values of attribute type
 | ------------------ | ------------------ | -------------------------------------------------------------------- | ------------------ |
 |frequency|text|The frequency level the power line is running on|`frequency=*`|
 |operator|text|Which company is handling this utility_lines|`operator=*`|
-|type|text| |(see table below)|
+|type|text|(see table below)| |
 |voltage|text|The voltage level the power line is running on|`voltage=*`|
 
 
@@ -1352,7 +1352,7 @@ Values of attribute type
 |Attributes          |type                |Description                                                           |osm_tags            |
 | ------------------ | ------------------ | -------------------------------------------------------------------- | ------------------ |
 |aggtype|text|Grouping several different 'type' to a common 'type' (aka enmu)| |
-|type|text| |(see table below)|
+|type|text|(see table below)| |
 
 
 Values of attribute type
@@ -1380,7 +1380,7 @@ Values of attribute type
 
 |Attributes          |type                |Description                                                           |osm_tags            |
 | ------------------ | ------------------ | -------------------------------------------------------------------- | ------------------ |
-|type|text| |(see table below)|
+|type|text|(see table below)| |
 
 
 Values of attribute type
@@ -1404,7 +1404,7 @@ Values of attribute type
 
 |Attributes          |type                |Description                                                           |osm_tags            |
 | ------------------ | ------------------ | -------------------------------------------------------------------- | ------------------ |
-|type|int| |(see table below)|
+|type|int|(see table below)| |
 |width|int|The the measurement or extent of something from side to side; the lesser of two or the least of three dimensions of a body.|`width=*`|
 
 
@@ -1424,7 +1424,7 @@ Values of attribute type
 
 |Attributes          |type                |Description                                                           |osm_tags            |
 | ------------------ | ------------------ | -------------------------------------------------------------------- | ------------------ |
-|type|text| |(see table below)|
+|type|text|(see table below)| |
 
 
 Values of attribute type

--- a/documentation.md
+++ b/documentation.md
@@ -516,9 +516,20 @@ Values of attribute type
 |Attributes          |type                |Description                                                           |osm_tags            |
 | ------------------ | ------------------ | -------------------------------------------------------------------- | ------------------ |
 |ref|text|Reference number of this road unset for railways.|`ref=*`|
-|status|text|P for Planned; C for underconstruction; D for disused; A for abandoned; this is dependent on the values.| |
+|status|text| |(see table below)|
 |type|text| |(see table below)|
 |z_order|smallint|The layer tag is used to describe vertical relationships between different crossing or overlapping map features. Use this in combination with bridge/tunnel tags when one way passes above or under another one.|`layer=*`|
+
+
+Values of attribute status
+
+|values              |osm_tags            |description                                                           |
+| ------------------ | ------------------ | -------------------------------------------------------------------- |
+|P|`highway=planned` or `railway=planned`| |
+|C|`highway=construction` or `railway=construction`| |
+|D|`highway=disused` or `railway=disused`| |
+|A|`highway=abandoned` or `railway=abandoned`| |
+
 
 
 Values of attribute type

--- a/documentation.md
+++ b/documentation.md
@@ -517,7 +517,7 @@ Values of attribute type
 | ------------------ | ------------------ | -------------------------------------------------------------------- | ------------------ |
 |ref|text|Reference number of this road unset for railways.|`ref=*`|
 |status|text| |(see table below)|
-|sub_type|text|See attribute 'type' of layer road_l and railway_l, respectively.|`highway=planned`+`planned=*` or `highway=construction`+`construction=*` or `highway=disused`+`disused=*` or `highway=abandoned`+`abandoned=*` or `railway=planned`+`planned=*` or `railway=construction`+`construction=*` or `railway=disused`+`disused=*` or `railway=abandoned`+`abandoned=*`|
+|sub_type|text|See attribute 'type' of layer road_l and railway_l, respectively.|`highway=proposed`+`proposed=*` or `highway=planned`+`planned=*` or `highway=construction`+`construction=*` or `highway=disused`+`disused=*` or `highway=abandoned`+`abandoned=*` or `railway=proposed`+`proposed=*` or `railway=planned`+`planned=*` or `railway=construction`+`construction=*` or `railway=disused`+`disused=*` or `railway=abandoned`+`abandoned=*`|
 |type|text| |(see table below)|
 |z_order|smallint|The layer tag is used to describe vertical relationships between different crossing or overlapping map features. Use this in combination with bridge/tunnel tags when one way passes above or under another one.|`layer=*`|
 
@@ -526,7 +526,7 @@ Values of attribute status
 
 |values              |osm_tags            |description                                                           |
 | ------------------ | ------------------ | -------------------------------------------------------------------- |
-|P|`highway=planned` or `railway=planned`| |
+|P|`highway=proposed` or `railway=proposed` or `highway=planned` or `railway=planned`| |
 |C|`highway=construction` or `railway=construction`| |
 |D|`highway=disused` or `railway=disused`| |
 |A|`highway=abandoned` or `railway=abandoned`| |
@@ -537,8 +537,8 @@ Values of attribute type
 
 |values              |osm_tags            |description                                                           |
 | ------------------ | ------------------ | -------------------------------------------------------------------- |
-|highway|`highway=planned` or `highway=construction` or `highway=disused` or `highway=abandoned`|Contains roads which are disused, planned, under constructions or abandoned. These type of features will be place in this table to keep the feature but display as not available|
-|railway|`railway=planned` or `railway=construction` or `railway=disused` or `railway=abandoned`|Contains railways which are disused, planned, under constructions or abandoned. These type of features will be place in this table to keep the feature but display as not available|
+|highway|`highway=proposed` or `highway=planned` or `highway=construction` or `highway=disused` or `highway=abandoned`|Contains roads which are disused, planned, under constructions or abandoned. These type of features will be place in this table to keep the feature but display as not available|
+|railway|`railway=proposed` or `railway=planned` or `railway=construction` or `railway=disused` or `railway=abandoned`|Contains railways which are disused, planned, under constructions or abandoned. These type of features will be place in this table to keep the feature but display as not available|
 
 
 ## poi_a

--- a/osmaxx_schema.yaml
+++ b/osmaxx_schema.yaml
@@ -523,6 +523,8 @@ layers:
         values: !!omap
           - "P":
               osm_tags:
+                - "highway": 'proposed'
+                - "railway": 'proposed'
                 - "highway": 'planned'
                 - "railway": 'planned'
           - "C":
@@ -542,6 +544,7 @@ layers:
         values:
           "highway":
             osm_tags:
+              - "highway": 'proposed'
               - "highway": 'planned'
               - "highway": 'construction'
               - "highway": 'disused'
@@ -549,6 +552,7 @@ layers:
             description: 'Contains roads which are disused, planned, under constructions or abandoned. These type of features will be place in this table to keep the feature but display as not available'
           "railway":
             osm_tags:
+              - "railway": 'proposed'
               - "railway": 'planned'
               - "railway": 'construction'
               - "railway": 'disused'
@@ -558,10 +562,12 @@ layers:
         type: text
         description: "See attribute 'type' of layer road_l and railway_l, respectively."
         osm_tags:
+          - !!omap ["highway": "proposed", "proposed": "*"]
           - !!omap ["highway": "planned", "planned": "*"]
           - !!omap ["highway": "construction", "construction": "*"]
           - !!omap ["highway": "disused", "disused": "*"]
           - !!omap ["highway": 'abandoned', "abandoned": "*"]
+          - !!omap ["railway": "proposed", "proposed": "*"]
           - !!omap ["railway": "planned", "planned": "*"]
           - !!omap ["railway": "construction", "construction": "*"]
           - !!omap ["railway": "disused", "disused": "*"]

--- a/osmaxx_schema.yaml
+++ b/osmaxx_schema.yaml
@@ -520,7 +520,23 @@ layers:
           - "layer": '*'
       "status":
         type: text
-        description: 'P for Planned; C for underconstruction; D for disused; A for abandoned; this is dependent on the values.'
+        values: !!omap
+          - "P":
+              osm_tags:
+                - "highway": 'planned'
+                - "railway": 'planned'
+          - "C":
+              osm_tags:
+                - "highway": 'construction'
+                - "railway": 'construction'
+          - "D":
+              osm_tags:
+                - "highway": 'disused'
+                - "railway": 'disused'
+          - "A":
+              osm_tags:
+                - "highway": 'abandoned'
+                - "railway": 'abandoned'
       "type":
         type: text
         values:

--- a/osmaxx_schema.yaml
+++ b/osmaxx_schema.yaml
@@ -554,6 +554,18 @@ layers:
               - "railway": 'disused'
               - "railway": 'abandoned'
             description: 'Contains railways which are disused, planned, under constructions or abandoned. These type of features will be place in this table to keep the feature but display as not available'
+      "sub_type":
+        type: text
+        description: "See attribute 'type' of layer road_l and railway_l, respectively."
+        osm_tags:
+          - !!omap ["highway": "planned", "planned": "*"]
+          - !!omap ["highway": "construction", "construction": "*"]
+          - !!omap ["highway": "disused", "disused": "*"]
+          - !!omap ["highway": 'abandoned', "abandoned": "*"]
+          - !!omap ["railway": "planned", "planned": "*"]
+          - !!omap ["railway": "construction", "construction": "*"]
+          - !!omap ["railway": "disused", "disused": "*"]
+          - !!omap ["railway": 'abandoned', "abandoned": "*"]
   "poi_p": &layer_poi_p
     attributes:
       "aggtype":

--- a/templates/attribute_values.md.jinja2
+++ b/templates/attribute_values.md.jinja2
@@ -14,6 +14,6 @@ Values of attribute {{ attribute_name }}
         |{{ definition['correlated_attributes'][attribute_name] -}}
     {%- endfor -%}
     |{{ value }}|
-    {{- osm.tag_combinations(definition['osm_tags'], default=' ') }}|
+    {{- osm.tag_combinations(definition['osm_tags'])|default(' ', boolean=True) }}|
     {{- definition['description']|default(' ') }}|
 {% endfor -%}

--- a/templates/attribute_values.md.jinja2
+++ b/templates/attribute_values.md.jinja2
@@ -14,6 +14,6 @@ Values of attribute {{ attribute_name }}
         |{{ definition['correlated_attributes'][attribute_name] -}}
     {%- endfor -%}
     |{{ value }}|
-    {{- osm.tag_combinations(definition['osm_tags']) }}|
+    {{- osm.tag_combinations(definition['osm_tags'], default=' ') }}|
     {{- definition['description']|default(' ') }}|
 {% endfor -%}

--- a/templates/attribute_values.md.jinja2
+++ b/templates/attribute_values.md.jinja2
@@ -1,4 +1,4 @@
-
+{% import 'osm.md.jinja2' as osm %}
 Values of attribute {{ attribute_name }}
 
 {% for attribute_name in correlated_attributes -%}
@@ -14,20 +14,6 @@ Values of attribute {{ attribute_name }}
         |{{ definition['correlated_attributes'][attribute_name] -}}
     {%- endfor -%}
     |{{ value }}|
-    {%- set or_sep = joiner(' or ') -%}
-    {%- for tag_combination in definition['osm_tags'] -%}
-        {{- or_sep() -}}
-        {%- set and_sep = joiner('+') -%}
-        {%- for key, value in tag_combination|dictsort_unless_ordered -%}
-            {{- and_sep() -}}
-            {%- if value == '__ABSENT__' -%}
-                <code>{{ key }}<strong>&ne;\*</strong></code>
-            {%- else -%}
-                `{{ key }}={{ value }}`
-            {%- endif -%}
-        {%- endfor -%}
-    {%- else -%}
-        {{ ' ' }}
-    {%- endfor %}|
+    {{- osm.tag_combinations(definition['osm_tags']) }}|
     {{- definition['description']|default(' ') }}|
 {% endfor -%}

--- a/templates/attribute_values.md.jinja2
+++ b/templates/attribute_values.md.jinja2
@@ -26,8 +26,8 @@ Values of attribute {{ attribute_name }}
                 `{{ key }}={{ value }}`
             {%- endif -%}
         {%- endfor -%}
-    {% else %}
+    {%- else -%}
         {{ ' ' }}
-    {%- endfor -%}|
+    {%- endfor %}|
     {{- definition['description']|default(' ') }}|
 {% endfor -%}

--- a/templates/layer_attributes.md.jinja2
+++ b/templates/layer_attributes.md.jinja2
@@ -11,6 +11,6 @@
         {%- endif -%}
         {{- [attribute['description'], reference_to_value_table]|reject('undefined')|join(' ')|default(' ') -}}
     {%- endwith %}|
-    {{- osm.tag_combinations(attribute['osm_tags']) }}|
+    {{- osm.tag_combinations(attribute['osm_tags'], default=' ') }}|
 {% endfor %}
 {% endif -%}

--- a/templates/layer_attributes.md.jinja2
+++ b/templates/layer_attributes.md.jinja2
@@ -1,3 +1,4 @@
+{% import 'osm.md.jinja2' as osm -%}
 {% if attributes %}
 |Attributes          |type                |Description                                                           |osm_tags            |
 | ------------------ | ------------------ | -------------------------------------------------------------------- | ------------------ |
@@ -10,20 +11,6 @@
         {%- endif -%}
         {{- [attribute['description'], reference_to_value_table]|reject('undefined')|join(' ')|default(' ') -}}
     {%- endwith %}|
-    {%- set or_sep = joiner(' or ') -%}
-    {%- for tag_combination in attribute['osm_tags'] -%}
-        {{- or_sep() -}}
-        {%- set and_sep = joiner('+') -%}
-        {%- for key, value in tag_combination|dictsort_unless_ordered -%}
-            {{- and_sep() -}}
-            {%- if value == '__ABSENT__' -%}
-                <code>{{ key }}<strong>&ne;\*</strong></code>
-            {%- else -%}
-                `{{ key }}={{ value }}`
-            {%- endif -%}
-        {%- endfor -%}
-    {%- else -%}
-        {{ ' ' }}
-    {%- endfor %}|
+    {{- osm.tag_combinations(attribute['osm_tags']) }}|
 {% endfor %}
 {% endif -%}

--- a/templates/layer_attributes.md.jinja2
+++ b/templates/layer_attributes.md.jinja2
@@ -11,6 +11,6 @@
         {%- endif -%}
         {{- [attribute['description'], reference_to_value_table]|reject('undefined')|join(' ')|default(' ') -}}
     {%- endwith %}|
-    {{- osm.tag_combinations(attribute['osm_tags'], default=' ') }}|
+    {{- osm.tag_combinations(attribute['osm_tags'])|default(' ', boolean=True) }}|
 {% endfor %}
 {% endif -%}

--- a/templates/layer_attributes.md.jinja2
+++ b/templates/layer_attributes.md.jinja2
@@ -5,9 +5,17 @@
     {{- attribute_name }}|
     {{- attribute['type'] }}|
     {{- attribute['description']|default(' ') }}|
+    {%- set or_sep = joiner(' or ') -%}
     {%- for tag_combination in attribute['osm_tags'] -%}
+        {{- or_sep() -}}
+        {%- set and_sep = joiner('+') -%}
         {%- for key, value in tag_combination|dictsort_unless_ordered -%}
-            `{{ key }}={{ value }}`
+            {{- and_sep() -}}
+            {%- if value == '__ABSENT__' -%}
+                <code>{{ key }}<strong>&ne;\*</strong></code>
+            {%- else -%}
+                `{{ key }}={{ value }}`
+            {%- endif -%}
         {%- endfor -%}
     {%- else -%}
         {%- if 'values' in attribute -%}

--- a/templates/layer_attributes.md.jinja2
+++ b/templates/layer_attributes.md.jinja2
@@ -4,7 +4,12 @@
 {% for attribute_name, attribute in attributes|dictsort_unless_ordered -%}|
     {{- attribute_name }}|
     {{- attribute['type'] }}|
-    {{- attribute['description']|default(' ') }}|
+    {%- with -%}
+        {%- if 'values' in attribute -%}
+            {%- set reference_to_value_table = '(see table below)' -%}
+        {%- endif -%}
+        {{- [attribute['description'], reference_to_value_table]|reject('undefined')|join(' ')|default(' ') -}}
+    {%- endwith %}|
     {%- set or_sep = joiner(' or ') -%}
     {%- for tag_combination in attribute['osm_tags'] -%}
         {{- or_sep() -}}
@@ -18,11 +23,7 @@
             {%- endif -%}
         {%- endfor -%}
     {%- else -%}
-        {%- if 'values' in attribute -%}
-            (see table below)
-        {%- else -%}
-            {{ ' ' }}
-        {%- endif -%}
+        {{ ' ' }}
     {%- endfor %}|
 {% endfor %}
 {% endif -%}

--- a/templates/osm.md.jinja2
+++ b/templates/osm.md.jinja2
@@ -1,13 +1,17 @@
+{% macro tag(key, value) -%}
+    {% if value == '__ABSENT__' -%}
+        <code>{{ key }}<strong>&ne;\*</strong></code>
+    {%- else -%}
+        `{{ key }}={{ value }}`
+    {%- endif %}
+{%- endmacro %}
+
 {% macro tag_combination(osm_tag_combination, combination_separator) -%}
     {{ combination_separator() -}}
     {%- set and_sep = joiner('+') -%}
     {%- for key, value in osm_tag_combination|dictsort_unless_ordered -%}
         {{- and_sep() -}}
-        {%- if value == '__ABSENT__' -%}
-            <code>{{ key }}<strong>&ne;\*</strong></code>
-        {%- else -%}
-            `{{ key }}={{ value }}`
-        {%- endif -%}
+        {{- tag(key, value) -}}
     {%- endfor %}
 {%- endmacro %}
 

--- a/templates/osm.md.jinja2
+++ b/templates/osm.md.jinja2
@@ -1,4 +1,4 @@
-{% macro tag_combinations(osm_tags, default='') -%}
+{% macro tag_combinations(osm_tags) -%}
     {% set or_sep = joiner(' or ') -%}
     {%- for tag_combination in osm_tags -%}
         {{- or_sep() -}}
@@ -11,7 +11,5 @@
                 `{{ key }}={{ value }}`
             {%- endif -%}
         {%- endfor -%}
-    {%- else -%}
-        {{ default }}
     {%- endfor %}
 {%- endmacro %}

--- a/templates/osm.md.jinja2
+++ b/templates/osm.md.jinja2
@@ -1,15 +1,19 @@
+{% macro tag_combination(osm_tag_combination, combination_separator) -%}
+    {{ combination_separator() -}}
+    {%- set and_sep = joiner('+') -%}
+    {%- for key, value in osm_tag_combination|dictsort_unless_ordered -%}
+        {{- and_sep() -}}
+        {%- if value == '__ABSENT__' -%}
+            <code>{{ key }}<strong>&ne;\*</strong></code>
+        {%- else -%}
+            `{{ key }}={{ value }}`
+        {%- endif -%}
+    {%- endfor %}
+{%- endmacro %}
+
 {% macro tag_combinations(osm_tag_combinations) -%}
     {% set or_sep = joiner(' or ') -%}
-    {%- for tag_combination in osm_tag_combinations -%}
-        {{- or_sep() -}}
-        {%- set and_sep = joiner('+') -%}
-        {%- for key, value in tag_combination|dictsort_unless_ordered -%}
-            {{- and_sep() -}}
-            {%- if value == '__ABSENT__' -%}
-                <code>{{ key }}<strong>&ne;\*</strong></code>
-            {%- else -%}
-                `{{ key }}={{ value }}`
-            {%- endif -%}
-        {%- endfor -%}
+    {%- for osm_tag_combination in osm_tag_combinations -%}
+        {{ tag_combination(osm_tag_combination, or_sep) }}
     {%- endfor %}
 {%- endmacro %}

--- a/templates/osm.md.jinja2
+++ b/templates/osm.md.jinja2
@@ -1,4 +1,4 @@
-{% macro tag_combinations(osm_tags) -%}
+{% macro tag_combinations(osm_tags, default='') -%}
     {% set or_sep = joiner(' or ') -%}
     {%- for tag_combination in osm_tags -%}
         {{- or_sep() -}}
@@ -12,6 +12,6 @@
             {%- endif -%}
         {%- endfor -%}
     {%- else -%}
-        {{ ' ' }}
+        {{ default }}
     {%- endfor %}
 {%- endmacro %}

--- a/templates/osm.md.jinja2
+++ b/templates/osm.md.jinja2
@@ -1,0 +1,17 @@
+{% macro tag_combinations(osm_tags) -%}
+    {% set or_sep = joiner(' or ') -%}
+    {%- for tag_combination in osm_tags -%}
+        {{- or_sep() -}}
+        {%- set and_sep = joiner('+') -%}
+        {%- for key, value in tag_combination|dictsort_unless_ordered -%}
+            {{- and_sep() -}}
+            {%- if value == '__ABSENT__' -%}
+                <code>{{ key }}<strong>&ne;\*</strong></code>
+            {%- else -%}
+                `{{ key }}={{ value }}`
+            {%- endif -%}
+        {%- endfor -%}
+    {%- else -%}
+        {{ ' ' }}
+    {%- endfor %}
+{%- endmacro %}

--- a/templates/osm.md.jinja2
+++ b/templates/osm.md.jinja2
@@ -1,6 +1,6 @@
-{% macro tag_combinations(osm_tags) -%}
+{% macro tag_combinations(osm_tag_combinations) -%}
     {% set or_sep = joiner(' or ') -%}
-    {%- for tag_combination in osm_tags -%}
+    {%- for tag_combination in osm_tag_combinations -%}
         {{- or_sep() -}}
         {%- set and_sep = joiner('+') -%}
         {%- for key, value in tag_combination|dictsort_unless_ordered -%}

--- a/yamltomd.py
+++ b/yamltomd.py
@@ -3,7 +3,12 @@ from jinja2 import Environment, FileSystemLoader
 from collections import OrderedDict
 from ruamel import yaml
 
-env = Environment(loader=FileSystemLoader(searchpath='templates'))
+env = Environment(
+    loader=FileSystemLoader(searchpath='templates'),
+    extensions=[
+        'jinja2.ext.with_',
+    ],
+)
 
 
 def do_dictsort_unless_ordered(value):


### PR DESCRIPTION
- document changes from
  - geometalab/osmaxx-frontend#423 new attribute `nonop_l.sub_type` (PR geometalab/osmaxx-frontend#520)
  - geometalab/osmaxx-frontend#524 OSM status `proposed`== OSM status `planned` (PR geometalab/osmaxx-frontend#525)
- document `nonop_l.status` values as values instead of in "discription" prose
- move "(see table below)" references to "Description" column
### Reviewed by
- [x] @hixi
- [ ] @sfkeller
