### PR TITLE
Feature/#4 qgis road colors

### DIFF
--- a/osmaxx-symbology/colored map.qgs
+++ b/osmaxx-symbology/colored map.qgs
@@ -11884,7 +11884,7 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="0,0,0,0,0,0"/>
             </layer>
           </symbol>
-          <symbol alpha="0.298039" clip_to_extent="1" type="line" name="20">
+          <symbol alpha="1" clip_to_extent="1" type="line" name="20">
             <layer pass="0" class="SimpleLine" locked="1">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -11892,9 +11892,9 @@ def my_form_open(dialog, layer, feature):
               <prop k="customdash_unit" v="MM"/>
               <prop k="draw_inside_polygon" v="0"/>
               <prop k="joinstyle" v="bevel"/>
-              <prop k="line_color" v="112,112,104,255"/>
+              <prop k="line_color" v="225,225,225,255"/>
               <prop k="line_style" v="solid"/>
-              <prop k="line_width" v="3.26"/>
+              <prop k="line_width" v="1.76"/>
               <prop k="line_width_unit" v="MM"/>
               <prop k="offset" v="0"/>
               <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
@@ -11909,9 +11909,9 @@ def my_form_open(dialog, layer, feature):
               <prop k="customdash_unit" v="MM"/>
               <prop k="draw_inside_polygon" v="0"/>
               <prop k="joinstyle" v="round"/>
-              <prop k="line_color" v="230,232,233,255"/>
+              <prop k="line_color" v="255,255,255,255"/>
               <prop k="line_style" v="solid"/>
-              <prop k="line_width" v="2.26"/>
+              <prop k="line_width" v="0.76"/>
               <prop k="line_width_unit" v="MM"/>
               <prop k="offset" v="0"/>
               <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>

--- a/osmaxx-symbology/colored map.qgs
+++ b/osmaxx-symbology/colored map.qgs
@@ -11761,9 +11761,26 @@ def my_form_open(dialog, layer, feature):
               <prop k="customdash_unit" v="MM"/>
               <prop k="draw_inside_polygon" v="0"/>
               <prop k="joinstyle" v="bevel"/>
-              <prop k="line_color" v="187,154,69,255"/>
+              <prop k="line_color" v="228,228,228,255"/>
               <prop k="line_style" v="solid"/>
-              <prop k="line_width" v="0.26"/>
+              <prop k="line_width" v="2.26"/>
+              <prop k="line_width_unit" v="MM"/>
+              <prop k="offset" v="0"/>
+              <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+              <prop k="offset_unit" v="MM"/>
+              <prop k="use_custom_dash" v="0"/>
+              <prop k="width_map_unit_scale" v="0,0,0,0,0,0"/>
+            </layer>
+            <layer pass="0" class="SimpleLine" locked="0">
+              <prop k="capstyle" v="square"/>
+              <prop k="customdash" v="5;2"/>
+              <prop k="customdash_map_unit_scale" v="0,0,0,0,0,0"/>
+              <prop k="customdash_unit" v="MM"/>
+              <prop k="draw_inside_polygon" v="0"/>
+              <prop k="joinstyle" v="bevel"/>
+              <prop k="line_color" v="255,255,255,255"/>
+              <prop k="line_style" v="solid"/>
+              <prop k="line_width" v="1.26"/>
               <prop k="line_width_unit" v="MM"/>
               <prop k="offset" v="0"/>
               <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>

--- a/osmaxx-symbology/colored map.qgs
+++ b/osmaxx-symbology/colored map.qgs
@@ -12021,7 +12021,7 @@ def my_form_open(dialog, layer, feature):
               <prop k="customdash_unit" v="MM"/>
               <prop k="draw_inside_polygon" v="0"/>
               <prop k="joinstyle" v="bevel"/>
-              <prop k="line_color" v="255,158,106,255"/>
+              <prop k="line_color" v="255,196,102,255"/>
               <prop k="line_style" v="solid"/>
               <prop k="line_width" v="2"/>
               <prop k="line_width_unit" v="MM"/>

--- a/osmaxx-symbology/colored map.qgs
+++ b/osmaxx-symbology/colored map.qgs
@@ -12171,7 +12171,7 @@ def my_form_open(dialog, layer, feature):
               <prop k="customdash_unit" v="MM"/>
               <prop k="draw_inside_polygon" v="0"/>
               <prop k="joinstyle" v="round"/>
-              <prop k="line_color" v="255,119,52,255"/>
+              <prop k="line_color" v="255,179,51,255"/>
               <prop k="line_style" v="solid"/>
               <prop k="line_width" v="3.36"/>
               <prop k="line_width_unit" v="MM"/>

--- a/osmaxx-symbology/colored map.qgs
+++ b/osmaxx-symbology/colored map.qgs
@@ -11947,7 +11947,7 @@ def my_form_open(dialog, layer, feature):
               <prop k="customdash_unit" v="MM"/>
               <prop k="draw_inside_polygon" v="0"/>
               <prop k="joinstyle" v="round"/>
-              <prop k="line_color" v="150,150,150,255"/>
+              <prop k="line_color" v="225,225,225,255"/>
               <prop k="line_style" v="solid"/>
               <prop k="line_width" v="2.96"/>
               <prop k="line_width_unit" v="MM"/>
@@ -11964,7 +11964,7 @@ def my_form_open(dialog, layer, feature):
               <prop k="customdash_unit" v="MM"/>
               <prop k="draw_inside_polygon" v="0"/>
               <prop k="joinstyle" v="round"/>
-              <prop k="line_color" v="255,236,206,255"/>
+              <prop k="line_color" v="255,255,255,255"/>
               <prop k="line_style" v="solid"/>
               <prop k="line_width" v="2.79371"/>
               <prop k="line_width_unit" v="MM"/>

--- a/osmaxx-symbology/colored map.qgs
+++ b/osmaxx-symbology/colored map.qgs
@@ -12190,7 +12190,7 @@ def my_form_open(dialog, layer, feature):
               <prop k="customdash_unit" v="MM"/>
               <prop k="draw_inside_polygon" v="0"/>
               <prop k="joinstyle" v="bevel"/>
-              <prop k="line_color" v="255,119,52,255"/>
+              <prop k="line_color" v="255,179,51,255"/>
               <prop k="line_style" v="solid"/>
               <prop k="line_width" v="2.6"/>
               <prop k="line_width_unit" v="MM"/>

--- a/osmaxx-symbology/colored map.qgs
+++ b/osmaxx-symbology/colored map.qgs
@@ -11799,9 +11799,26 @@ def my_form_open(dialog, layer, feature):
               <prop k="customdash_unit" v="MM"/>
               <prop k="draw_inside_polygon" v="0"/>
               <prop k="joinstyle" v="bevel"/>
-              <prop k="line_color" v="187,154,69,255"/>
+              <prop k="line_color" v="227,227,227,255"/>
               <prop k="line_style" v="solid"/>
-              <prop k="line_width" v="0.26"/>
+              <prop k="line_width" v="2.26"/>
+              <prop k="line_width_unit" v="MM"/>
+              <prop k="offset" v="0"/>
+              <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+              <prop k="offset_unit" v="MM"/>
+              <prop k="use_custom_dash" v="0"/>
+              <prop k="width_map_unit_scale" v="0,0,0,0,0,0"/>
+            </layer>
+            <layer pass="0" class="SimpleLine" locked="0">
+              <prop k="capstyle" v="square"/>
+              <prop k="customdash" v="5;2"/>
+              <prop k="customdash_map_unit_scale" v="0,0,0,0,0,0"/>
+              <prop k="customdash_unit" v="MM"/>
+              <prop k="draw_inside_polygon" v="0"/>
+              <prop k="joinstyle" v="bevel"/>
+              <prop k="line_color" v="255,255,255,255"/>
+              <prop k="line_style" v="solid"/>
+              <prop k="line_width" v="1.26"/>
               <prop k="line_width_unit" v="MM"/>
               <prop k="offset" v="0"/>
               <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>

--- a/osmaxx-symbology/colored map.qgs
+++ b/osmaxx-symbology/colored map.qgs
@@ -12016,16 +12016,33 @@ def my_form_open(dialog, layer, feature):
             </layer>
           </symbol>
           <symbol alpha="1" clip_to_extent="1" type="line" name="26">
-            <layer pass="0" class="SimpleLine" locked="0">
-              <prop k="capstyle" v="square"/>
+            <layer pass="0" class="SimpleLine" locked="1">
+              <prop k="capstyle" v="round"/>
               <prop k="customdash" v="5;2"/>
               <prop k="customdash_map_unit_scale" v="0,0,0,0,0,0"/>
               <prop k="customdash_unit" v="MM"/>
               <prop k="draw_inside_polygon" v="0"/>
-              <prop k="joinstyle" v="bevel"/>
-              <prop k="line_color" v="187,187,187,255"/>
-              <prop k="line_style" v="dash"/>
-              <prop k="line_width" v="0.26"/>
+              <prop k="joinstyle" v="round"/>
+              <prop k="line_color" v="227,227,227,255"/>
+              <prop k="line_style" v="solid"/>
+              <prop k="line_width" v="2.26"/>
+              <prop k="line_width_unit" v="MM"/>
+              <prop k="offset" v="0"/>
+              <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+              <prop k="offset_unit" v="MM"/>
+              <prop k="use_custom_dash" v="0"/>
+              <prop k="width_map_unit_scale" v="0,0,0,0,0,0"/>
+            </layer>
+            <layer pass="0" class="SimpleLine" locked="0">
+              <prop k="capstyle" v="round"/>
+              <prop k="customdash" v="5;2"/>
+              <prop k="customdash_map_unit_scale" v="0,0,0,0,0,0"/>
+              <prop k="customdash_unit" v="MM"/>
+              <prop k="draw_inside_polygon" v="0"/>
+              <prop k="joinstyle" v="round"/>
+              <prop k="line_color" v="255,255,255,255"/>
+              <prop k="line_style" v="solid"/>
+              <prop k="line_width" v="1.26"/>
               <prop k="line_width_unit" v="MM"/>
               <prop k="offset" v="0"/>
               <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>

--- a/osmaxx-symbology/colored map.qgs
+++ b/osmaxx-symbology/colored map.qgs
@@ -11854,7 +11854,7 @@ def my_form_open(dialog, layer, feature):
               <prop k="customdash_unit" v="MM"/>
               <prop k="draw_inside_polygon" v="0"/>
               <prop k="joinstyle" v="bevel"/>
-              <prop k="line_color" v="255,206,128,255"/>
+              <prop k="line_color" v="255,242,102,255"/>
               <prop k="line_style" v="solid"/>
               <prop k="line_width" v="2.2"/>
               <prop k="line_width_unit" v="MM"/>

--- a/osmaxx-symbology/colored map.qgs
+++ b/osmaxx-symbology/colored map.qgs
@@ -11716,23 +11716,6 @@ def my_form_open(dialog, layer, feature):
             </layer>
           </symbol>
           <symbol alpha="1" clip_to_extent="1" type="line" name="13">
-            <layer pass="0" class="SimpleLine" locked="1">
-              <prop k="capstyle" v="round"/>
-              <prop k="customdash" v="5;2"/>
-              <prop k="customdash_map_unit_scale" v="0,0,0,0,0,0"/>
-              <prop k="customdash_unit" v="MM"/>
-              <prop k="draw_inside_polygon" v="0"/>
-              <prop k="joinstyle" v="round"/>
-              <prop k="line_color" v="76,38,0,255"/>
-              <prop k="line_style" v="solid"/>
-              <prop k="line_width" v="3.36"/>
-              <prop k="line_width_unit" v="MM"/>
-              <prop k="offset" v="0"/>
-              <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
-              <prop k="offset_unit" v="MM"/>
-              <prop k="use_custom_dash" v="0"/>
-              <prop k="width_map_unit_scale" v="0,0,0,0,0,0"/>
-            </layer>
             <layer pass="18" class="SimpleLine" locked="0">
               <prop k="capstyle" v="round"/>
               <prop k="customdash" v="5;2"/>

--- a/osmaxx-symbology/colored map.qgs
+++ b/osmaxx-symbology/colored map.qgs
@@ -12002,7 +12002,7 @@ def my_form_open(dialog, layer, feature):
               <prop k="customdash_unit" v="MM"/>
               <prop k="draw_inside_polygon" v="0"/>
               <prop k="joinstyle" v="bevel"/>
-              <prop k="line_color" v="255,158,106,255"/>
+              <prop k="line_color" v="255,196,102,255"/>
               <prop k="line_style" v="solid"/>
               <prop k="line_width" v="2.6"/>
               <prop k="line_width_unit" v="MM"/>
@@ -12435,7 +12435,7 @@ def my_form_open(dialog, layer, feature):
       <annotationform>.</annotationform>
       <excludeAttributesWMS/>
       <excludeAttributesWFS/>
-      <attributeactions default="0"/>
+      <attributeactions default="-1"/>
       <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns/>
       </attributetableconfig>

--- a/osmaxx-symbology/colored map.qgs
+++ b/osmaxx-symbology/colored map.qgs
@@ -11740,7 +11740,7 @@ def my_form_open(dialog, layer, feature):
               <prop k="customdash_unit" v="MM"/>
               <prop k="draw_inside_polygon" v="0"/>
               <prop k="joinstyle" v="round"/>
-              <prop k="line_color" v="255,117,138,255"/>
+              <prop k="line_color" v="255,168,153,255"/>
               <prop k="line_style" v="solid"/>
               <prop k="line_width" v="3.17124"/>
               <prop k="line_width_unit" v="MM"/>

--- a/osmaxx-symbology/colored map.qgs
+++ b/osmaxx-symbology/colored map.qgs
@@ -11835,7 +11835,7 @@ def my_form_open(dialog, layer, feature):
               <prop k="customdash_unit" v="MM"/>
               <prop k="draw_inside_polygon" v="0"/>
               <prop k="joinstyle" v="round"/>
-              <prop k="line_color" v="255,206,128,255"/>
+              <prop k="line_color" v="255,242,102,255"/>
               <prop k="line_style" v="solid"/>
               <prop k="line_width" v="2.98247"/>
               <prop k="line_width_unit" v="MM"/>

--- a/osmaxx-symbology/colored map.qgs
+++ b/osmaxx-symbology/colored map.qgs
@@ -11759,7 +11759,7 @@ def my_form_open(dialog, layer, feature):
               <prop k="customdash_unit" v="MM"/>
               <prop k="draw_inside_polygon" v="0"/>
               <prop k="joinstyle" v="bevel"/>
-              <prop k="line_color" v="255,117,138,255"/>
+              <prop k="line_color" v="255,168,153,255"/>
               <prop k="line_style" v="solid"/>
               <prop k="line_width" v="2.5"/>
               <prop k="line_width_unit" v="MM"/>


### PR DESCRIPTION
Part of #4

Adapt most road colors and some road line styles to those documented in [`ArcGIS_OSMaxx_Styles_2016.pdf`](https://github.com/geometalab/osmaxx-docs/blob/24fed1d73f6edc5ec1b1ad667692ee5f100df1ca/osmaxx-symbology/ArcGIS/ArcGIS_OSMaxx_Styles_2016.pdf)
