### PR TITLE
Add documentation of our ArcGIS labeling style M4 (branch feature/arcgis_labeling_docu_m4)

### DIFF
--- a/osmaxx-symbology/ArcGIS/label_styles.md
+++ b/osmaxx-symbology/ArcGIS/label_styles.md
@@ -1,0 +1,363 @@
+# OSMaxx labeling style ArcGIS for scale level M4 (1:25'000)
+
+Font choice for all objects: `DejaVu Sans.ttf`
+
+Font sizes are given in Desktop Publishing Points (DTP).
+
+## Labels in group layer "Nur labeling":
+
+### address_p
+
+| feature type         | shown in M4 | size | modifyers    | Color (RGB) |
+|----------------------|:-----------:|-----:|--------------|-------------|
+| (all)                | no          |  5.5 | Italic       | 0/0/0       |
+
+
+### military_p
+
+| feature type         | shown in M4 | size | modifyers    | Color (RGB) |
+|----------------------|:-----------:|-----:|--------------|-------------|
+| naval base           | yes         |  6.4 | Italic       | 70/70/0     |
+| airfield             | yes         |  6.0 | Italic       | 70/70/0     |
+| danger_area          | no          |  6.0 | Italic       | 70/70/0     |
+| barracks             | yes         |  6.5 | Italic       | 70/70/0     |
+| bunker               | no          |  6.0 | Italic       | 70/70/0     |
+| range                | no          |  6.0 | Italic       | 70/70/0     |
+| others               | no          |  6.0 | Italic       | 70/70/0     |
+
+
+### geoname_p
+
+| feature type         | shown in M4 | size | modifyers    | Color (RGB) |
+|----------------------|:-----------:|-----:|--------------|-------------|
+| city                 | yes         | 11.0 | Bold, italic | 205/102/102 |
+| county               | yes         | 13.0 | Bold, italic | 78/78/78    |
+| hamlet               | yes         |  7.0 | Italic       | 78/78/78    |
+| island               | yes         |  6.0 | Italic       | 78/78/78    |
+| locality             | yes         |  6.0 | Italic       | 78/78/78    |
+| region               | yes         | 10.0 | Italic       | 78/78/78    |
+| state                | yes         | 13.0 | Bold, italic | 130/15/90   |
+| suburb               | yes         |  8.0 | Italic       | 78/78/78    |
+| town                 | yes         | 11.0 | Bold, italic | 51/51/51    |
+| village              | yes         |  9.0 | Bold, italic | 78/78/78    |
+
+
+### geoname_l
+
+| feature type         | shown in M4 | size | modifyers    | Color (RGB) |
+|----------------------|:-----------:|-----:|--------------|-------------|
+| (all)                | no          |  6.0 | regular      | 200/100/150 |
+
+
+### adminarea_a
+
+| feature type         | shown in M4 | size | modifyers    | Color (RGB) |
+|----------------------|:-----------:|-----:|--------------|-------------|
+| national             | yes         |  8.0 | regular      | 190/60/150  |
+| admin_level3         | yes         |  7.0 | regular      | 130/15/90   |
+| admin_level4         | yes         |  7.0 | regular      | 130/15/90   |
+| admin_level5         | yes         |  7.0 | regular      | 130/15/90   |
+| admin_level6         | yes         |  6.0 | regular      | 168/0/132   |
+| admin_level7         | yes         |  5.0 | regular      | 135/0/72    |
+| admin_level8         | yes         |  5.0 | regular      | 135/0/72    |
+| admin_level9         | no          |  5.0 | regular      | 135/0/72    |
+| admin_level10        | no          |  5.0 | regular      | 135/0/72    |
+| admin_level11        | no          |  5.0 | regular      | 135/0/72    |
+| national_park        | yes         |  6.0 | Italic       | 0/110/70    |
+| protected_area       | yes         |  6.0 | Italic       | 0/110/70    |
+
+
+### poi_p
+
+| feature type         | shown in M4 | size | modifyers    | Color (RGB) |
+|----------------------|:-----------:|-----:|--------------|-------------|
+| check_point          | yes         |  5.5 | Italic       | 0/0/0       |
+| government           | yes         |  5.5 | Italic       | 0/0/0       |
+| embassy              | yes         |  5.5 | Italic       | 0/0/0       |
+| hospital             | no          |  5.5 | Italic       | 0/0/0       |
+| stadium              | no          |  5.5 | Italic       | 0/0/0       |
+| university           | yes         |  5.5 | Italic       | 0/0/0       |
+| college              | no          |  5.5 | Italic       | 0/0/0       |
+| school               | no          |  5.5 | Italic       | 0/0/0       |
+| marketplace          | no          |  5.5 | Italic       | 0/0/0       |
+| cemetery             | no          |  5.5 | Italic       | 0/0/0       |
+| grave_yard           | no          |  5.5 | Italic       | 0/0/0       |
+| castle               | yes         |  5.5 | Italic       | 0/0/0       |
+| police               | no          |  5.5 | Italic       | 0/0/0       |
+| zoo                  | no          |  5.5 | Italic       | 0/0/0       |
+| camp_site            | no          |  5.5 | Italic       | 0/0/0       |
+| comm_tower           | no          |  5.5 | Italic       | 0/0/0       |
+| golf_course          | yes         |  5.5 | Italic       | 0/0/0       |
+| water_well           | no          |  5.5 | Italic       | 0/0/0       |
+| water_tower          | no          |  5.5 | Italic       | 0/0/0       |
+| lighthouse           | no          |  5.5 | Italic       | 0/0/0       |
+
+
+### pow_p
+
+| feature type         | shown in M4 | size | modifyers    | Color (RGB) |
+|----------------------|:-----------:|-----:|--------------|-------------|
+| (all)                | yes         |  5.5 | Italic       | 102/94/56   |
+
+
+### transport_p
+
+| feature type         | shown in M4 | size | modifyers    | Color (RGB) |
+|----------------------|:-----------:|-----:|--------------|-------------|
+| airport              | yes         |  7.0 | regular      | 0/92/230    |
+| airfield             | no          |  5.5 | regular      | 78/78/78    |
+| railway_station      | yes         |  6.5 | regular      | 200/0/0     |
+| bus_station          | yes         |  6.0 | regular      | 0/92/230    |
+| railway_halt         | no          |  5.5 | regular      | 78/78/78    |
+| bus_stop             | no          |  5.5 | regular      | 78/78/78    |
+| helipad              | no          |  5.5 | regular      | 78/78/78    |
+| ferry_terminal       | yes         |  6.5 | regular      | 0/92/230    |
+
+
+### traffic_p
+
+| feature type         | shown in M4 | size | modifyers    | Color (RGB) |
+|----------------------|:-----------:|-----:|--------------|-------------|
+| (all)                | no          |  5.5 | regular      | 102/102/102 |
+
+
+### utility_p
+
+| feature type         | shown in M4 | size | modifyers    | Color (RGB) |
+|----------------------|:-----------:|-----:|--------------|-------------|
+| plant                | yes         |  5.5 | regular      | 102/102/102 |
+| nuclear              | yes         |  5.5 | regular      | 102/102/102 |
+| fossil               | yes         |  5.5 | regular      | 102/102/102 |
+| hydro                | yes         |  5.5 | regular      | 102/102/102 |
+| wind                 | no          |  5.5 | regular      | 102/102/102 |
+| solar                | no          |  5.5 | regular      | 102/102/102 |
+| substation           | no          |  5.5 | regular      | 102/102/102 |
+| pole                 | no          |  5.5 | regular      | 102/102/102 |
+| tower                | no          |  5.5 | regular      | 102/102/102 |
+
+
+### water_p
+
+| feature type         | shown in M4 | size | modifyers    | Color (RGB) |
+|----------------------|:-----------:|-----:|--------------|-------------|
+| dam                  | yes         |  5.5 | Italic       | 0/92/230    |
+| waterfall            | yes         |  5.5 | Italic       | 0/92/230    |
+| spring               | no          |  5.5 | Italic       | 0/92/230    |
+| reservoir_covered    | no          |  5.5 | Italic       | 0/92/230    |
+
+
+### natural_p
+
+| feature type         | shown in M4 | size | modifyers    | Color (RGB) |
+|----------------------|:-----------:|-----:|--------------|-------------|
+| volcano              | yes         |  6.0 | Italic       | 25/25/25    |
+| peak                 | yes         |  6.0 | Italic       | 25/25/25    |
+| cave_entrance        | yes         |  6.0 | Italic       | 25/25/25    |
+| rock                 | no          |  6.0 | Italic       | 25/25/25    |
+
+
+### boundary_l
+
+| feature type         | shown in M4 | size | modifyers    | Color (RGB) |
+|----------------------|:-----------:|-----:|--------------|-------------|
+| (all)                | no          |  6.0 | regular      | 200/100/150 |
+
+
+### coastlines_l
+
+| feature type         | shown in M4 | size | modifyers    | Color (RGB) |
+|----------------------|:-----------:|-----:|--------------|-------------|
+|                      | no          |  6.0 | Italic       | 255/255/255 |
+
+
+### transport_l
+
+| feature type         | shown in M4 | size | modifyers    | Color (RGB) |
+|----------------------|:-----------:|-----:|--------------|-------------|
+| (all)                | no          |  5.5 | regular      | 130/0/230   |
+
+
+### utility_l
+
+| feature type         | shown in M4 | size | modifyers    | Color (RGB) |
+|----------------------|:-----------:|-----:|--------------|-------------|
+| (all)                | no          |  5.5 | Italic       | 78/78/78    |
+
+
+### misc_l
+
+| feature type         | shown in M4 | size | modifyers    | Color (RGB) |
+|----------------------|:-----------:|-----:|--------------|-------------|
+| (all)                | no          |  5.5 | Italic       | 78/78/78    |
+
+
+### railway_l
+
+| feature type         | shown in M4 | size | modifyers    | Color (RGB) |
+|----------------------|:-----------:|-----:|--------------|-------------|
+| (all)                | no          |  5.5 | Italic       | 52/52/52    |
+
+
+### road_l
+
+| feature type         | shown in M4 | size | modifyers    | Color (RGB) |
+|----------------------|:-----------:|-----:|--------------|-------------|
+| trunk                | yes         |  6.5 | regular      | 0/0/0       |
+| trunk_link           | no          |  6.0 | regular      | 0/0/0       |
+| motorway             | yes         |  6.5 | regular      | 0/0/0       |
+| motorway_link        | no          |  6.0 | regular      | 0/0/0       |
+| primary              | yes         |  6.5 | regular      | 0/0/0       |
+| primary_link         | no          |  6.0 | regular      | 0/0/0       |
+| secondary            | yes         |  6.0 | regular      | 0/0/0       |
+| secondary_link       | no          |  5.5 | regular      | 0/0/0       |
+| tertiary             | no          |  6.0 | regular      | 0/0/0       |
+| unclassified         | yes         |  6.0 | regular      | 0/0/0       |
+| roundabout           | no          |  5.5 | regular      | 0/0/0       |
+| residential          | no          |  5.5 | regular      | 0/0/0       |
+| track                | no          |  5.5 | regular      | 0/0/0       |
+| grade1               | no          |  5.5 | regular      | 0/0/0       |
+| grade2               | no          |  5.5 | regular      | 0/0/0       |
+| path                 | no          |  5.5 | regular      | 0/0/0       |
+
+
+### route_l
+
+| feature type         | shown in M4 | size | modifyers    | Color (RGB) |
+|----------------------|:-----------:|-----:|--------------|-------------|
+|                      | no          |  6.0 | italic       | 0/28/255    |
+
+
+### nonop_l
+
+| feature type         | shown in M4 | size | modifyers    | Color (RGB) |
+|----------------------|:-----------:|-----:|--------------|-------------|
+|                      | no          |  5.5 | Italic       | 78/78/78    |
+
+
+### water_l
+
+| feature type         | shown in M4 | size | modifyers    | Color (RGB) |
+|----------------------|:-----------:|-----:|--------------|-------------|
+| pier                 | no          |  6.0 | Italic       | 102/102/102 |
+| river                | yes         |  7.0 | Italic       | 0/92/230    |
+| stream               | yes         |  6.0 | Italic       | 0/92/230    |
+| canal                | yes         |  6.0 | Italic       | 0/92/230    |
+| drain                | no          |  6.0 | Italic       | 102/102/102 |
+|                      | no          |  6.0 | Italic       | 78/78/78    |
+|                      | no          |  6.0 | regular      | 78/78/78    |
+|                      | no          |  5.5 | Italic       | 102/102/102 |
+
+
+### water_a
+
+| feature type         | shown in M4 | size | modifyers    | Color (RGB) |
+|----------------------|:-----------:|-----:|--------------|-------------|
+| pier                 | no          |  6.0 | Italic       | 0/0/0       |
+| weir                 | no          |  6.0 | Italic       | 0/0/0       |
+| riverbank            | no          |  6.0 | Italic       | 0/92/230    |
+| water                | yes         |  6.0 | Italic       | 0/92/230    |
+| bank                 | no          |  6.0 | Italic       | 0/0/0       |
+
+
+### military_a
+
+| feature type         | shown in M4 | size | modifyers    | Color (RGB) |
+|----------------------|:-----------:|-----:|--------------|-------------|
+| (all)                | no          |  6.0 | Italic       | 70/70/0     |
+
+
+### utility_a
+
+| feature type         | shown in M4 | size | modifyers    | Color (RGB) |
+|----------------------|:-----------:|-----:|--------------|-------------|
+| (all)                | no          |  6.0 | Italic       | 0/0/0       |
+
+
+### building_a
+
+| feature type         | shown in M4 | size | modifyers    | Color (RGB) |
+|----------------------|:-----------:|-----:|--------------|-------------|
+| (all)                | no          |  5.5 | regular      | 0/0/0       |
+
+
+### poi_a
+
+| feature type         | shown in M4 | size | modifyers    | Color (RGB) |
+|----------------------|:-----------:|-----:|--------------|-------------|
+| soccer_pitch         | no          |  6.0 | Italic       | 51/51/51    |
+| swimming_pool        | no          |  6.0 | Italic       | 51/51/51    |
+| tennis_pitch         | no          |  6.0 | Italic       | 51/51/51    |
+| sports_centre        | no          |  6.0 | Italic       | 51/51/51    |
+| cemetery             | no          |  6.0 | Italic       | 51/51/51    |
+| grave_yard           | no          |  6.0 | Italic       | 51/51/51    |
+| government           | no          |  6.0 | Italic       | 51/51/51    |
+| hospital             | yes         |  6.0 | Italic       | 51/51/51    |
+| marketplace          | no          |  6.0 | Italic       | 51/51/51    |
+| school               | no          |  6.0 | Italic       | 51/51/51    |
+| stadium              | yes         |  6.0 | Italic       | 51/51/51    |
+| university           | no          |  6.0 | Italic       | 51/51/51    |
+| camp_site            | no          |  6.0 | Italic       | 51/51/51    |
+| caravan_site         | no          |  6.0 | Italic       | 51/51/51    |
+| golf_course          | no          |  6.0 | Italic       | 51/51/51    |
+| zoo                  | yes         |  6.0 | Italic       | 51/51/51    |
+
+
+### landuse_a
+
+| feature type         | shown in M4 | size | modifyers    | Color (RGB) |
+|----------------------|:-----------:|-----:|--------------|-------------|
+| military             | no          |  6.0 | Italic       | 51/51/51    |
+| nature_reserve       | no          |  6.0 | Italic       | 51/51/51    |
+| greenhouse           | no          |  6.0 | Italic       | 51/51/51    |
+| quarry               | no          |  6.0 | Italic       | 51/51/51    |
+| reservoir            | no          |  6.0 | Italic       | 51/51/51    |
+| landfill             | yes         |  6.0 | Italic       | 51/51/51    |
+| park                 | no          |  6.0 | Italic       | 51/51/51    |
+| recreation_ground    | no          |  6.0 | Italic       | 51/51/51    |
+| railway              | no          |  6.0 | Italic       | 51/51/51    |
+| industrial           | yes         |  6.0 | Italic       | 51/51/51    |
+| orchard              | no          |  6.0 | Italic       | 51/51/51    |
+| plant_nursery        | no          |  6.0 | Italic       | 51/51/51    |
+| allotments           | no          |  6.0 | Italic       | 51/51/51    |
+| vineyard             | no          |  6.0 | Italic       | 51/51/51    |
+| farm                 | no          |  6.0 | Italic       | 51/51/51    |
+| farmyard             | no          |  6.0 | Italic       | 51/51/51    |
+| grass                | no          |  6.0 | Italic       | 51/51/51    |
+| meadow               | no          |  6.0 | Italic       | 51/51/51    |
+| forest               | yes         |  6.0 | Italic       | 51/51/51    |
+| residential          | no          |  6.0 | Italic       | 51/51/51    |
+
+
+### natural_a
+
+| feature type         | shown in M4 | size | modifyers    | Color (RGB) |
+|----------------------|:-----------:|-----:|--------------|-------------|
+| moor                 | yes         |  6.0 | Italic       | 51/51/51    |
+| wetland              | yes         |  6.0 | Italic       | 51/51/51    |
+| mud                  | no          |  6.0 | Italic       | 51/51/51    |
+| glacier              | yes         |  6.0 | Italic       | 51/51/51    |
+| bare_rock            | no          |  6.0 | Italic       | 51/51/51    |
+| cliff                | no          |  6.0 | Italic       | 51/51/51    |
+| scree                | no          |  6.0 | Italic       | 51/51/51    |
+| heath                | yes         |  6.0 | Italic       | 51/51/51    |
+| scrub                | no          |  6.0 | Italic       | 51/51/51    |
+| beach                | no          |  6.0 | Italic       | 51/51/51    |
+| sand                 | no          |  6.0 | Italic       | 51/51/51    |
+| natural              | no          |  6.0 | Italic       | 51/51/51    |
+| fell                 | yes         |  6.0 | Italic       | 51/51/51    |
+| grassland            | no          |  6.0 | Italic       | 51/51/51    |
+| wood                 | yes         |  6.0 | Italic       | 51/51/51    |
+
+
+### land_polygon
+
+| feature type         | shown in M4 | size | modifyers    | Color (RGB) |
+|----------------------|:-----------:|-----:|--------------|-------------|
+|                      | no          |  6.0 | Italic       | 0/0/0       |
+
+
+### water_polygon
+
+| feature type         | shown in M4 | size | modifyers    | Color (RGB) |
+|----------------------|:-----------:|-----:|--------------|-------------|
+|                      | no          |  6.0 | Italic       | 0/0/0       |


### PR DESCRIPTION
Add documentation of our ArcGIS labeling style M4 based on `OSMaxx Beschriftungsstil ArcGis für Massstab M4.pdf` received from @cdeUG by email on 2016-08-17
### Reviewed by
- [x] @hixi
- [ ] @sfkeller
