### PR TITLE
Feature/fix airfield ways qgis symbology

### DIFF
--- a/osmaxx-symbology/QGIS/OSMaxx.qgs
+++ b/osmaxx-symbology/QGIS/OSMaxx.qgs
@@ -4601,55 +4601,15 @@ def my_form_open(dialog, layer, feature):
       </edittypes>
       <renderer-v2 attr="type" forceraster="0" symbollevels="0" type="categorizedSymbol" enableorderby="0">
         <categories>
-          <category render="true" symbol="0" value="runway" label="runway"/>
-          <category render="true" symbol="1" value="Taxiway" label="Taxiway"/>
-          <category render="true" symbol="2" value="city_wall" label="city_wall"/>
-          <category render="false" symbol="3" value="barrier" label="barrier"/>
-          <category render="true" symbol="4" value="wall" label="wall"/>
-          <category render="false" symbol="5" value="hedge" label="hedge"/>
-          <category render="false" symbol="6" value="fence" label="fence"/>
-          <category render="false" symbol="7" value="gate" label="gate"/>
+          <category render="true" symbol="0" value="city_wall" label="city_wall"/>
+          <category render="false" symbol="1" value="barrier" label="barrier"/>
+          <category render="true" symbol="2" value="wall" label="wall"/>
+          <category render="false" symbol="3" value="hedge" label="hedge"/>
+          <category render="false" symbol="4" value="fence" label="fence"/>
+          <category render="false" symbol="5" value="gate" label="gate"/>
         </categories>
         <symbols>
-          <symbol alpha="1" clip_to_extent="1" type="line" name="0">
-            <layer pass="0" class="SimpleLine" locked="0">
-              <prop k="capstyle" v="square"/>
-              <prop k="customdash" v="5;2"/>
-              <prop k="customdash_map_unit_scale" v="0,0,0,0,0,0"/>
-              <prop k="customdash_unit" v="MM"/>
-              <prop k="draw_inside_polygon" v="0"/>
-              <prop k="joinstyle" v="bevel"/>
-              <prop k="line_color" v="159,35,221,255"/>
-              <prop k="line_style" v="solid"/>
-              <prop k="line_width" v="1.26"/>
-              <prop k="line_width_unit" v="MM"/>
-              <prop k="offset" v="0"/>
-              <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
-              <prop k="offset_unit" v="MM"/>
-              <prop k="use_custom_dash" v="0"/>
-              <prop k="width_map_unit_scale" v="0,0,0,0,0,0"/>
-            </layer>
-          </symbol>
-          <symbol alpha="1" clip_to_extent="1" type="line" name="1">
-            <layer pass="0" class="SimpleLine" locked="0">
-              <prop k="capstyle" v="square"/>
-              <prop k="customdash" v="5;2"/>
-              <prop k="customdash_map_unit_scale" v="0,0,0,0,0,0"/>
-              <prop k="customdash_unit" v="MM"/>
-              <prop k="draw_inside_polygon" v="0"/>
-              <prop k="joinstyle" v="bevel"/>
-              <prop k="line_color" v="170,13,157,255"/>
-              <prop k="line_style" v="solid"/>
-              <prop k="line_width" v="0.4"/>
-              <prop k="line_width_unit" v="MM"/>
-              <prop k="offset" v="0"/>
-              <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
-              <prop k="offset_unit" v="MM"/>
-              <prop k="use_custom_dash" v="0"/>
-              <prop k="width_map_unit_scale" v="0,0,0,0,0,0"/>
-            </layer>
-          </symbol>
-          <symbol alpha="0.290196" clip_to_extent="1" type="line" name="2">
+          <symbol alpha="0.290196" clip_to_extent="1" type="line" name="0">
             <layer pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -4685,7 +4645,7 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="0,0,0,0,0,0"/>
             </layer>
           </symbol>
-          <symbol alpha="1" clip_to_extent="1" type="line" name="3">
+          <symbol alpha="1" clip_to_extent="1" type="line" name="1">
             <layer pass="1" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -4704,7 +4664,7 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="0,0,0,0,0,0"/>
             </layer>
           </symbol>
-          <symbol alpha="1" clip_to_extent="1" type="line" name="4">
+          <symbol alpha="1" clip_to_extent="1" type="line" name="2">
             <layer pass="0" class="MarkerLine" locked="0">
               <prop k="interval" v="1.5"/>
               <prop k="interval_map_unit_scale" v="0,0,0,0,0,0"/>
@@ -4717,7 +4677,7 @@ def my_form_open(dialog, layer, feature):
               <prop k="offset_unit" v="MM"/>
               <prop k="placement" v="interval"/>
               <prop k="rotate" v="1"/>
-              <symbol alpha="1" clip_to_extent="1" type="marker" name="@4@0">
+              <symbol alpha="1" clip_to_extent="1" type="marker" name="@2@0">
                 <layer pass="0" class="SimpleMarker" locked="0">
                   <prop k="angle" v="0"/>
                   <prop k="color" v="255,0,0,255"/>
@@ -4741,7 +4701,7 @@ def my_form_open(dialog, layer, feature):
               </symbol>
             </layer>
           </symbol>
-          <symbol alpha="1" clip_to_extent="1" type="line" name="5">
+          <symbol alpha="1" clip_to_extent="1" type="line" name="3">
             <layer pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -4760,7 +4720,7 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="0,0,0,0,0,0"/>
             </layer>
           </symbol>
-          <symbol alpha="1" clip_to_extent="1" type="line" name="6">
+          <symbol alpha="1" clip_to_extent="1" type="line" name="4">
             <layer pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -4779,7 +4739,7 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="0,0,0,0,0,0"/>
             </layer>
           </symbol>
-          <symbol alpha="1" clip_to_extent="1" type="line" name="7">
+          <symbol alpha="1" clip_to_extent="1" type="line" name="5">
             <layer pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -23478,6 +23438,50 @@ def my_form_open(dialog, layer, feature):
         </edittype>
       </edittypes>
       <renderer-v2 attr="type" forceraster="0" symbollevels="0" type="categorizedSymbol" enableorderby="0">
+        <categories>
+          <category render="true" symbol="0" value="runway" label="runway"/>
+          <category render="true" symbol="1" value="Taxiway" label="Taxiway"/>
+        </categories>
+        <symbols>
+          <symbol alpha="1" clip_to_extent="1" type="line" name="0">
+            <layer pass="0" class="SimpleLine" locked="0">
+              <prop k="capstyle" v="square"/>
+              <prop k="customdash" v="5;2"/>
+              <prop k="customdash_map_unit_scale" v="0,0,0,0,0,0"/>
+              <prop k="customdash_unit" v="MM"/>
+              <prop k="draw_inside_polygon" v="0"/>
+              <prop k="joinstyle" v="bevel"/>
+              <prop k="line_color" v="159,35,221,255"/>
+              <prop k="line_style" v="solid"/>
+              <prop k="line_width" v="1.26"/>
+              <prop k="line_width_unit" v="MM"/>
+              <prop k="offset" v="0"/>
+              <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+              <prop k="offset_unit" v="MM"/>
+              <prop k="use_custom_dash" v="0"/>
+              <prop k="width_map_unit_scale" v="0,0,0,0,0,0"/>
+            </layer>
+          </symbol>
+          <symbol alpha="1" clip_to_extent="1" type="line" name="1">
+            <layer pass="0" class="SimpleLine" locked="0">
+              <prop k="capstyle" v="square"/>
+              <prop k="customdash" v="5;2"/>
+              <prop k="customdash_map_unit_scale" v="0,0,0,0,0,0"/>
+              <prop k="customdash_unit" v="MM"/>
+              <prop k="draw_inside_polygon" v="0"/>
+              <prop k="joinstyle" v="bevel"/>
+              <prop k="line_color" v="170,13,157,255"/>
+              <prop k="line_style" v="solid"/>
+              <prop k="line_width" v="0.4"/>
+              <prop k="line_width_unit" v="MM"/>
+              <prop k="offset" v="0"/>
+              <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+              <prop k="offset_unit" v="MM"/>
+              <prop k="use_custom_dash" v="0"/>
+              <prop k="width_map_unit_scale" v="0,0,0,0,0,0"/>
+            </layer>
+          </symbol>
+        </symbols>
         <source-symbol>
           <symbol alpha="1" clip_to_extent="1" type="line" name="0">
             <layer pass="0" class="SimpleLine" locked="0">

--- a/osmaxx-symbology/QGIS/OSMaxx.qgs
+++ b/osmaxx-symbology/QGIS/OSMaxx.qgs
@@ -23440,7 +23440,7 @@ def my_form_open(dialog, layer, feature):
       <renderer-v2 attr="type" forceraster="0" symbollevels="0" type="categorizedSymbol" enableorderby="0">
         <categories>
           <category render="true" symbol="0" value="runway" label="runway"/>
-          <category render="true" symbol="1" value="Taxiway" label="Taxiway"/>
+          <category render="true" symbol="1" value="taxiway" label="Taxiway"/>
         </categories>
         <symbols>
           <symbol alpha="1" clip_to_extent="1" type="line" name="0">

--- a/osmaxx-symbology/QGIS/OSMaxx.qgs
+++ b/osmaxx-symbology/QGIS/OSMaxx.qgs
@@ -4603,13 +4603,12 @@ def my_form_open(dialog, layer, feature):
         <categories>
           <category render="true" symbol="0" value="runway" label="runway"/>
           <category render="true" symbol="1" value="Taxiway" label="Taxiway"/>
-          <category render="true" symbol="2" value="runway" label="runway"/>
-          <category render="true" symbol="3" value="city_wall" label="city_wall"/>
-          <category render="false" symbol="4" value="barrier" label="barrier"/>
-          <category render="true" symbol="5" value="wall" label="wall"/>
-          <category render="false" symbol="6" value="hedge" label="hedge"/>
-          <category render="false" symbol="7" value="fence" label="fence"/>
-          <category render="false" symbol="8" value="gate" label="gate"/>
+          <category render="true" symbol="2" value="city_wall" label="city_wall"/>
+          <category render="false" symbol="3" value="barrier" label="barrier"/>
+          <category render="true" symbol="4" value="wall" label="wall"/>
+          <category render="false" symbol="5" value="hedge" label="hedge"/>
+          <category render="false" symbol="6" value="fence" label="fence"/>
+          <category render="false" symbol="7" value="gate" label="gate"/>
         </categories>
         <symbols>
           <symbol alpha="1" clip_to_extent="1" type="line" name="0">
@@ -4650,26 +4649,7 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="0,0,0,0,0,0"/>
             </layer>
           </symbol>
-          <symbol alpha="1" clip_to_extent="1" type="line" name="2">
-            <layer pass="0" class="SimpleLine" locked="0">
-              <prop k="capstyle" v="square"/>
-              <prop k="customdash" v="5;2"/>
-              <prop k="customdash_map_unit_scale" v="0,0,0,0,0,0"/>
-              <prop k="customdash_unit" v="MM"/>
-              <prop k="draw_inside_polygon" v="0"/>
-              <prop k="joinstyle" v="bevel"/>
-              <prop k="line_color" v="137,173,18,255"/>
-              <prop k="line_style" v="solid"/>
-              <prop k="line_width" v="0.26"/>
-              <prop k="line_width_unit" v="MM"/>
-              <prop k="offset" v="0"/>
-              <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
-              <prop k="offset_unit" v="MM"/>
-              <prop k="use_custom_dash" v="0"/>
-              <prop k="width_map_unit_scale" v="0,0,0,0,0,0"/>
-            </layer>
-          </symbol>
-          <symbol alpha="0.290196" clip_to_extent="1" type="line" name="3">
+          <symbol alpha="0.290196" clip_to_extent="1" type="line" name="2">
             <layer pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -4705,7 +4685,7 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="0,0,0,0,0,0"/>
             </layer>
           </symbol>
-          <symbol alpha="1" clip_to_extent="1" type="line" name="4">
+          <symbol alpha="1" clip_to_extent="1" type="line" name="3">
             <layer pass="1" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -4724,7 +4704,7 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="0,0,0,0,0,0"/>
             </layer>
           </symbol>
-          <symbol alpha="1" clip_to_extent="1" type="line" name="5">
+          <symbol alpha="1" clip_to_extent="1" type="line" name="4">
             <layer pass="0" class="MarkerLine" locked="0">
               <prop k="interval" v="1.5"/>
               <prop k="interval_map_unit_scale" v="0,0,0,0,0,0"/>
@@ -4737,7 +4717,7 @@ def my_form_open(dialog, layer, feature):
               <prop k="offset_unit" v="MM"/>
               <prop k="placement" v="interval"/>
               <prop k="rotate" v="1"/>
-              <symbol alpha="1" clip_to_extent="1" type="marker" name="@5@0">
+              <symbol alpha="1" clip_to_extent="1" type="marker" name="@4@0">
                 <layer pass="0" class="SimpleMarker" locked="0">
                   <prop k="angle" v="0"/>
                   <prop k="color" v="255,0,0,255"/>
@@ -4761,7 +4741,7 @@ def my_form_open(dialog, layer, feature):
               </symbol>
             </layer>
           </symbol>
-          <symbol alpha="1" clip_to_extent="1" type="line" name="6">
+          <symbol alpha="1" clip_to_extent="1" type="line" name="5">
             <layer pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -4780,7 +4760,7 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="0,0,0,0,0,0"/>
             </layer>
           </symbol>
-          <symbol alpha="1" clip_to_extent="1" type="line" name="7">
+          <symbol alpha="1" clip_to_extent="1" type="line" name="6">
             <layer pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>
@@ -4799,7 +4779,7 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="0,0,0,0,0,0"/>
             </layer>
           </symbol>
-          <symbol alpha="1" clip_to_extent="1" type="line" name="8">
+          <symbol alpha="1" clip_to_extent="1" type="line" name="7">
             <layer pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
               <prop k="customdash" v="5;2"/>

--- a/osmaxx-symbology/QGIS/OSMaxx.qgs
+++ b/osmaxx-symbology/QGIS/OSMaxx.qgs
@@ -23477,8 +23477,8 @@ def my_form_open(dialog, layer, feature):
           <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
         </edittype>
       </edittypes>
-      <renderer-v2 forceraster="0" symbollevels="0" type="singleSymbol" enableorderby="0">
-        <symbols>
+      <renderer-v2 attr="type" forceraster="0" symbollevels="0" type="categorizedSymbol" enableorderby="0">
+        <source-symbol>
           <symbol alpha="1" clip_to_extent="1" type="line" name="0">
             <layer pass="0" class="SimpleLine" locked="0">
               <prop k="capstyle" v="square"/>
@@ -23498,7 +23498,7 @@ def my_form_open(dialog, layer, feature):
               <prop k="width_map_unit_scale" v="0,0,0,0,0,0"/>
             </layer>
           </symbol>
-        </symbols>
+        </source-symbol>
         <rotation/>
         <sizescale scalemethod="diameter"/>
       </renderer-v2>


### PR DESCRIPTION
The linestring features `taxiway` and `runway` are not in layer [`misc_l`](https://github.com/geometalab/osmaxx/blob/develop/docs/osmaxx_data_schema.md#misc_l) (see SQL in [`bootstrap/sql/filter/misc/`](https://github.com/geometalab/osmaxx/tree/35a5f1bdb2c6137b7b05b730e0aef52c811108ac/osmaxx/conversion/converters/converter_gis/bootstrap/sql/filter/misc)) but in layer [`transport_l`](https://github.com/geometalab/osmaxx/blob/develop/docs/osmaxx_data_schema.md#transport_l) (see SQL at [`bootstrap/sql/filter/transport/050_air_traffic.sql`](https://github.com/geometalab/osmaxx/blob/35a5f1bdb2c6137b7b05b730e0aef52c811108ac/osmaxx/conversion/converters/converter_gis/bootstrap/sql/filter/transport/050_air_traffic.sql#L31)). So the respective symbol categories need to be on that layer in QGIS, too.
### Reviewed by
- [ ] @hixi
